### PR TITLE
Update Vercel AI SDK implementation

### DIFF
--- a/app/vercel-ai-streamed/api/route.ts
+++ b/app/vercel-ai-streamed/api/route.ts
@@ -1,0 +1,18 @@
+import { streamObject } from "ai";
+import { openai } from "@ai-sdk/openai";
+
+import { RecipeSchema } from "@/src/recipeSchema";
+
+const modelName = "gpt-4o-2024-08-06";
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json();
+
+  const result = await streamObject({
+    model: openai(modelName, { structuredOutputs: true }),
+    schema: RecipeSchema,
+    prompt: `Recipe for ${prompt || "chocolate brownies"}`,
+  });
+
+  return result.toTextStreamResponse();
+}

--- a/app/vercel-ai-streamed/page.tsx
+++ b/app/vercel-ai-streamed/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { experimental_useObject as useObject } from "ai/react";
+import { Input } from "@/components/ui/input";
+import { RecipeCard } from "@/components/recipe-card";
+
+import { RecipeSchema } from "@/src/recipeSchema";
+import { Loading } from "@/components/loading";
+
+export default function VercelAiPage() {
+  const [prompt, setPrompt] = useState("Spaghetti Carbonara");
+  const { object, submit, isLoading } = useObject({
+    schema: RecipeSchema,
+    api: "/vercel-ai-streamed/api",
+    initialValue: {
+      name: "",
+      ingredients: [],
+      steps: [],
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Input
+        value={prompt}
+        disabled={isLoading}
+        onChange={(e) => setPrompt(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            submit({ prompt });
+            setPrompt("");
+          }
+        }}
+        placeholder="What recipe do you want?"
+      />
+      {isLoading && <Loading />}
+      <RecipeCard recipe={object as any} />
+    </div>
+  );
+}

--- a/app/vercel-ai/api/route.ts
+++ b/app/vercel-ai/api/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: Request) {
   const { prompt } = await req.json();
 
   const { object } = await generateObject({
-    model: openai(modelName),
+    model: openai(modelName, { structuredOutputs: true }),
     schema: RecipeSchema,
     prompt: `Recipe for ${prompt || "chocolate brownies"}`,
   });


### PR DESCRIPTION
Hey! Loved this video. This PR:

- adds the structured output flag to use OpenAIs structured output parsing
- adds a streamed example using the `streamObject` function instead of `generateObject`